### PR TITLE
enable rebuild if required

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,6 +50,6 @@ image="alpine/k8s"
 
 status=$(curl -sL https://hub.docker.com/v2/repositories/${image}/tags/${tag})
 echo $status
-if [[ "${status}" =~ "not found" ]]; then
+if [[ ( "${status}" =~ "not found" ) || ( ${REBUILD} == "true" ) ]]; then
    build
 fi


### PR DESCRIPTION
enable rebuild if required. 

It can be triggered via travis CI's variable `REBUILD`. 

![Screen Shot 2020-05-18 at 6 49 59 pm](https://user-images.githubusercontent.com/8954908/82193204-6b8f6780-9938-11ea-956a-1b877b457666.png)
