### PR TITLE
Feature/#9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,42 @@ RUN apk add --update --no-cache python3 && \
 # Install jq
 RUN apk add --update --no-cache jq
 
+# install glibc compatibility for alpine
+ENV GLIBC_VER=2.31-r0
+
+RUN apk --no-cache add \
+        binutils \
+        curl \
+    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && apk add --no-cache \
+        glibc-${GLIBC_VER}.apk \
+        glibc-bin-${GLIBC_VER}.apk \
+    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli \
+    && rm -rf \
+        awscliv2.zip \
+        aws \
+        /usr/local/aws-cli/v2/*/dist/aws_completer \
+        /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
+        /usr/local/aws-cli/v2/*/dist/awscli/examples \
+    && apk --no-cache del \
+        binutils \
+    && rm glibc-${GLIBC_VER}.apk \
+    && rm glibc-bin-${GLIBC_VER}.apk \
+    && rm -rf /var/cache/apk/*
+
 WORKDIR /apps
+
+# set ENTRYPOINT to switch default aws cli version when run the container.
+# if environment variable `version` is set to v2, default aws cli version is v2
+# if environment variable `version` is set to v1, not set or set to anything else, except v2, aws cli will be run from /usr/bin, and version is v1
+# you can still run specific version with full path in container.
+# aws cli v1 - installed at /usr/bin
+# aws cli v2 - installed at /usr/local/bin
+
+COPY entrypoint.sh /usr/local/bin
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,9 +88,6 @@ RUN apk --no-cache add \
 WORKDIR /apps
 
 # set ENTRYPOINT to switch default aws cli version when run the container.
-# if environment variable `version` is set to v2, default aws cli version is v2
-# if environment variable `version` is set to v1, not set or set to anything else, except v2, aws cli will be run from /usr/bin, and version is v1
-# you can still run specific version with full path in container.
 # aws cli v1 - installed at /usr/bin
 # aws cli v2 - installed at /usr/local/bin
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ docker build for AWS EKS, it can be used as normal kubectl tool as well
 - [helm-unittest](https://github.com/quintush/helm-unittest) (latest commit)
 - [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) (latest version when run the build)
 - [eksctl](https://github.com/weaveworks/eksctl) (latest version when run the build)
-- [awscli](https://github.com/aws/aws-cli) (latest version when run the build)
+- [awscli v1](https://github.com/aws/aws-cli) (latest version when run the build) - See notes below
+- [awscli v2](https://github.com/aws/aws-cli) (latest version when run the build) - See notes below
 - General tools, such as bash, curl
 
 ### Github Repo
@@ -44,3 +45,16 @@ export tag=1.13.12
 bash ./build.sh
 ```
 Then you need adjust the tag to other kubernetes version and run the build script again.
+
+# Notes to set aws cli version when run the container
+
+```
+$ docker run -ti --rm -e awscli=v2 alpine/k8s:1.18.2 aws --version
+aws-cli/2.1.22 Python/3.7.3 Linux/4.19.121-linuxkit exe/x86_64.alpine.3 prompt/off
+
+$ docker run -ti --rm -e awscli=v1 alpine/k8s:1.18.2 aws --version
+aws-cli/1.18.223 Python/3.8.7 Linux/4.19.121-linuxkit botocore/1.19.63
+
+$ docker run -ti --rm alpine/k8s:1.18.2 aws --version
+aws-cli/1.18.223 Python/3.8.7 Linux/4.19.121-linuxkit botocore/1.19.63
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
-# Push something on to $PATH depending on the environment
+
+# if environment variable `version` is set to v2, default aws cli version is v2
+# if environment variable `version` is set to v1, not set or set to anything else, except v2, aws cli will be run from /usr/bin, and version is v1
+# you can still run specific version with full path in container.
+# aws cli v1 - installed at /usr/bin
+# aws cli v2 - installed at /usr/local/bin
+
+# adjust $PATH depending on the environment variable "version"
 case "${version}" in
   v1) PATH="/usr/bin:$PATH" ;;
   v2) PATH="/usr/local/bin:$PATH" ;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-# if environment variable `version` is set to v2, default aws cli version is v2
-# if environment variable `version` is set to v1, not set or set to anything else, except v2, aws cli will be run from /usr/bin, and version is v1
+# if environment variable `awscli` is set to v2, default aws cli version is v2
+# if environment variable `awscli` is set to v1, not set or set to anything else, except v2, aws cli will be run from /usr/bin, and version is v1
 # you can still run specific version with full path in container.
 # aws cli v1 - installed at /usr/bin
 # aws cli v2 - installed at /usr/local/bin
 
-# adjust $PATH depending on the environment variable "version"
-case "${version}" in
+# adjust $PATH depending on the environment variable "awscli"
+case "${awscli}" in
   v1) PATH="/usr/bin:$PATH" ;;
   v2) PATH="/usr/local/bin:$PATH" ;;
   *)  PATH="/usr/bin:$PATH" ;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Push something on to $PATH depending on the environment
+case "${version}" in
+  v1) PATH="/usr/bin:$PATH" ;;
+  v2) PATH="/usr/local/bin:$PATH" ;;
+  *)  PATH="/usr/bin:$PATH" ;;
+esac
+# Then run the CMD
+exec "$@"


### PR DESCRIPTION
* install both aws cli v1 and v2 in same image
* set `ENTRYPOINT` to switch default aws cli version when run the container.
* if environment variable `awscli` is set to v2, default aws cli version is v2
*  if environment variable `awscli` is set to v1, not set or set to anything else, except v2, aws cli will be run from /usr/bin, and version is v1
*  you can still run specific version with full path in container.
   aws cli v1 - installed at /usr/bin, run as `/usr/bin/aws`
   aws cli v2 - installed at /usr/local/bin, run as `/usr/local/bin/aws`
* close #9 
* since aws cli v2 need `glibc`, image size increased for about 200MB.

Run a manual test:

```
$ docker build -t k8s .
$ docker run -ti --rm -e awscli=v2 k8s aws --version
aws-cli/2.1.22 Python/3.7.3 Linux/4.19.121-linuxkit exe/x86_64.alpine.3 prompt/off
$ docker run -ti --rm -e awscli=v1 k8s aws --version
aws-cli/1.18.223 Python/3.8.7 Linux/4.19.121-linuxkit botocore/1.19.63
$ docker run -ti --rm k8s --version
aws-cli/1.18.223 Python/3.8.7 Linux/4.19.121-linuxkit botocore/1.19.63
```