### PR TITLE
Install kubeseal (fix kustomize and remove temporary files)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM alpine
 ARG HELM_VERSION=3.2.1
 ARG KUBECTL_VERSION=1.17.5
 ARG KUSTOMIZE_VERSION=v3.8.1
+ARG KUBESEAL_VERSION=v0.15.0
 
 # https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
 ARG AWS_IAM_AUTH_VERSION_URL=https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.9/2020-08-04/bin/linux/amd64/aws-iam-authenticator
@@ -57,5 +58,10 @@ RUN apk add --update --no-cache python3 && \
 
 # Install jq
 RUN apk add --update --no-cache jq
+
+# Install kubeseal
+RUN curl -sL https://github.com/bitnami-labs/sealed-secrets/releases/download/${KUBESEAL_VERSION}/kubeseal-linux-amd64 -o kubeseal && \
+    mv kubeseal /usr/bin/kubeseal && \
+    chmod +x /usr/bin/kubeseal
 
 WORKDIR /apps

--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,13 @@ build() {
   kustomize_version=$(basename ${kustomize_release})
   echo $kustomize_version
 
-  docker build --no-cache --build-arg KUBECTL_VERSION=${tag} --build-arg HELM_VERSION=${helm} --build-arg KUSTOMIZE_VERSION=${kustomize_version} -t ${image}:${tag} .
+  # kubeseal latest
+  kubeseal_version=$(curl -s https://api.github.com/repos/bitnami-labs/sealed-secrets/releases | /usr/bin/jq -r '.[].tag_name | select(startswith("v"))' \
+    | sort -rV | head -n 1)
+  echo $kubeseal_version
+
+  docker build --no-cache --build-arg KUBECTL_VERSION=${tag} --build-arg HELM_VERSION=${helm} --build-arg KUSTOMIZE_VERSION=${kustomize_version} \
+    --build-arg KUBESEAL_VERSION=${kubeseal_version} -t ${image}:${tag} .
 
   # run test
   version=$(docker run -ti --rm ${image}:${tag} helm version --client)


### PR DESCRIPTION
This got a little out-of-hand unfortunately.
Started off with a simple request to install kubeseal, then expanded as I found the temporary files left in the container and the fact the kustomize version source was finding the wrong release.