### PR TITLE
Find just the release of kustomize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ RUN apk add --update --no-cache curl && \
 
 # Install kustomize (latest release)
 RUN curl -sLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
-  tar xvzf kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
-  mv kustomize /usr/bin/kustomize && \
-  chmod +x /usr/bin/kustomize
+    tar xvzf kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
+    mv kustomize /usr/bin/kustomize && \
+    chmod +x /usr/bin/kustomize
 
 # Install aws-iam-authenticator (latest version)
 RUN curl -LO ${AWS_IAM_AUTH_VERSION_URL} && \

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ build() {
 
   # jq
   DEBIAN_FRONTEND=noninteractive
-  apt-get update && apt-get -q -y install jq
+  sudo apt-get update && sudo apt-get -q -y install jq
 
   # kustomize latest
   kustomize_release=$(curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases | /usr/bin/jq -r '.[].tag_name | select(contains("kustomize"))' \

--- a/build.sh
+++ b/build.sh
@@ -16,8 +16,9 @@ build() {
   echo $helm
 
   # kustomize latest
-  kustomize_release_url=$(curl -vsIo /dev/null https://github.com/kubernetes-sigs/kustomize/releases/latest 2>&1 | grep 'location:' | cut -d ' ' -f 3)
-  kustomize_version=$(basename "$kustomize_release_url")
+  kustomize_release=$(curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases | /usr/bin/jq -r '.[].tag_name | select(contains("kustomize"))' \
+    | sort -rV | head -n 1)
+  kustomize_version=$(basename ${kustomize_release})
   echo $kustomize_version
 
   docker build --no-cache --build-arg KUBECTL_VERSION=${tag} --build-arg HELM_VERSION=${helm} --build-arg KUSTOMIZE_VERSION=${kustomize_version} -t ${image}:${tag} .

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,10 @@ build() {
   helm=$(echo $helm\" |grep -oP '(?<=tag\/v)[0-9][^"]*'|grep -v \-|sort -Vr|head -1)
   echo $helm
 
+  # jq
+  DEBIAN_FRONTEND=noninteractive
+  apt-get update && apt-get -q -y install jq
+
   # kustomize latest
   kustomize_release=$(curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases | /usr/bin/jq -r '.[].tag_name | select(contains("kustomize"))' \
     | sort -rV | head -n 1)


### PR DESCRIPTION
The kustomize project has multiple items being releases within a single repo, the previous version check would likely find the version of something that isn't the kustomize binary.
The travis xenial image doesn't have jq.