### PR TITLE
Cleaner and quieter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ RUN apk add --update --no-cache curl ca-certificates bash git && \
     rm -f /var/cache/apk/*
 
 # add helm-diff
-RUN helm plugin install https://github.com/databus23/helm-diff
+RUN helm plugin install https://github.com/databus23/helm-diff && rm -rf /tmp/helm-*
 
 # add helm-unittest
-RUN helm plugin install https://github.com/quintush/helm-unittest
+RUN helm plugin install https://github.com/quintush/helm-unittest && rm -rf /tmp/helm-*
 
 # Install kubectl (same version of aws esk)
 RUN apk add --update --no-cache curl && \
@@ -53,7 +53,8 @@ RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/down
 RUN apk add --update --no-cache python3 && \
     python3 -m ensurepip && \
     pip3 install --upgrade pip && \
-    pip3 install awscli
+    pip3 install awscli && \
+    pip3 cache purge
 
 # Install jq
 RUN apk add --update --no-cache jq

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,10 @@ ARG AWS_IAM_AUTH_VERSION_URL=https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.
 ENV BASE_URL="https://get.helm.sh"
 ENV TAR_FILE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
 RUN apk add --update --no-cache curl ca-certificates bash git && \
-    curl -L ${BASE_URL}/${TAR_FILE} |tar xvz && \
+    curl -sL ${BASE_URL}/${TAR_FILE} | tar -xvz && \
     mv linux-amd64/helm /usr/bin/helm && \
     chmod +x /usr/bin/helm && \
-    rm -rf linux-amd64 && \
-    apk del curl && \
-    rm -f /var/cache/apk/*
+    rm -rf linux-amd64
 
 # add helm-diff
 RUN helm plugin install https://github.com/databus23/helm-diff && rm -rf /tmp/helm-*
@@ -28,8 +26,7 @@ RUN helm plugin install https://github.com/databus23/helm-diff && rm -rf /tmp/he
 RUN helm plugin install https://github.com/quintush/helm-unittest && rm -rf /tmp/helm-*
 
 # Install kubectl (same version of aws esk)
-RUN apk add --update --no-cache curl && \
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     mv kubectl /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
@@ -40,12 +37,12 @@ RUN curl -sLO https://github.com/kubernetes-sigs/kustomize/releases/download/kus
   chmod +x /usr/bin/kustomize
 
 # Install aws-iam-authenticator (latest version)
-RUN curl -LO ${AWS_IAM_AUTH_VERSION_URL} && \
+RUN curl -sLO ${AWS_IAM_AUTH_VERSION_URL} && \
     mv aws-iam-authenticator /usr/bin/aws-iam-authenticator && \
     chmod +x /usr/bin/aws-iam-authenticator
 
 # Install eksctl (latest version)
-RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && \
+RUN curl -sL "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && \
     mv /tmp/eksctl /usr/bin && \
     chmod +x /usr/bin/eksctl
 


### PR DESCRIPTION
You probably don't really care about quietness, but I've added a couple -s's to curl anyhow.
This is mostly to remove helm plugin and pip cache/temporary files to make the containers smaller. IIRC helm was leaving ~50MB in /tmp.
Have also removed the slightly redundant removal of curl just to install it again.