### PR TITLE
Add helm push plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN helm plugin install https://github.com/databus23/helm-diff && rm -rf /tmp/he
 # add helm-unittest
 RUN helm plugin install https://github.com/quintush/helm-unittest && rm -rf /tmp/helm-*
 
+# add helm-push
+RUN helm plugin install https://github.com/chartmuseum/helm-push && rm -rf /tmp/helm-*
+
 # Install kubectl (same version of aws esk)
 RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     mv kubectl /usr/bin/kubectl && \

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you need support new versions, after AWS EKS released, please raise PR to upd
 - [helm](https://github.com/helm/helm) (latest release: https://github.com/helm/helm/releases/latest)
 - [helm-diff](https://github.com/databus23/helm-diff) (latest commit)
 - [helm-unittest](https://github.com/quintush/helm-unittest) (latest commit)
+- [helm-push](https://github.com/chartmuseum/helm-push) (latest commit)
 - [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) (latest version when run the build)
 - [eksctl](https://github.com/weaveworks/eksctl) (latest version when run the build)
 - [awscli v1](https://github.com/aws/aws-cli) (latest version when run the build)


### PR DESCRIPTION
PR to add the helm push plugin to the image.

With this plugin we can push a given helm chart to a given chart repository. (Chartmuseum, Harbor, etc.)