### PR TITLE
support arm64 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
 
+ARG TARGETARCH
+
 # Ignore to update versions here
 # docker build --no-cache --build-arg KUBECTL_VERSION=${tag} --build-arg HELM_VERSION=${helm} --build-arg KUSTOMIZE_VERSION=${kustomize_version} -t ${image}:${tag} .
 ARG HELM_VERSION=3.2.1
@@ -10,12 +12,12 @@ ARG KUBESEAL_VERSION=0.18.1
 # Install helm (latest release)
 # ENV BASE_URL="https://storage.googleapis.com/kubernetes-helm"
 ENV BASE_URL="https://get.helm.sh"
-ENV TAR_FILE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+ENV TAR_FILE="helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz"
 RUN apk add --update --no-cache curl ca-certificates bash git && \
     curl -sL ${BASE_URL}/${TAR_FILE} | tar -xvz && \
-    mv linux-amd64/helm /usr/bin/helm && \
+    mv linux-${TARGETARCH}/helm /usr/bin/helm && \
     chmod +x /usr/bin/helm && \
-    rm -rf linux-amd64
+    rm -rf linux-${TARGETARCH}
 
 # add helm-diff
 RUN helm plugin install https://github.com/databus23/helm-diff && rm -rf /tmp/helm-*
@@ -25,23 +27,23 @@ RUN helm plugin install https://github.com/quintush/helm-unittest && rm -rf /tmp
 
 # add helm-push
 RUN helm plugin install https://github.com/chartmuseum/helm-push && \
-  rm -rf /tmp/helm-* \
+    rm -rf /tmp/helm-* \
     /root/.local/share/helm/plugins/helm-push/testdata \
     /root/.cache/helm/plugins/https-github.com-chartmuseum-helm-push/testdata
 
 # Install kubectl (same version of aws esk)
-RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl && \
     mv kubectl /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
 # Install kustomize (latest release)
-RUN curl -sLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
-    tar xvzf kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
+RUN curl -sLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz && \
+    tar xvzf kustomize_${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz && \
     mv kustomize /usr/bin/kustomize && \
     chmod +x /usr/bin/kustomize
 
 # Install eksctl (latest version)
-RUN curl -sL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && \
+RUN curl -sL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_${TARGETARCH}.tar.gz" | tar xz -C /tmp && \
     mv /tmp/eksctl /usr/bin && \
     chmod +x /usr/bin/eksctl
 
@@ -58,14 +60,14 @@ RUN apk add --update --no-cache jq yq
 # https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
 # Install aws-iam-authenticator (latest version)
 RUN authenticator=$(curl -fs https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest | jq --raw-output '.name' | sed 's/^v//') && \
-    curl -fL https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${authenticator}/aws-iam-authenticator_${authenticator}_linux_amd64 -o /usr/bin/aws-iam-authenticator && \
+    curl -fL https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${authenticator}/aws-iam-authenticator_${authenticator}_linux_${TARGETARCH} -o /usr/bin/aws-iam-authenticator && \
     chmod +x /usr/bin/aws-iam-authenticator
 
 # Install for envsubst
 RUN apk add --update --no-cache gettext
 
 # Install kubeseal
-RUN curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz -o - | tar xz -C /usr/bin/ && \
+RUN curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-${TARGETARCH}.tar.gz -o - | tar xz -C /usr/bin/ && \
     chmod +x /usr/bin/kubeseal
 
 WORKDIR /apps

--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,8 @@ build() {
     | sort -rV | head -n 1 |sed 's/v//')
   echo "kubeseal version is $kubeseal_version"
 
-  docker build --no-cache \
+  docker buildx build --no-cache \
+    --platform=linux/amd64,linux/arm64 \
     --build-arg KUBECTL_VERSION=${tag} \
     --build-arg HELM_VERSION=${helm} \
     --build-arg KUSTOMIZE_VERSION=${kustomize_version} \


### PR DESCRIPTION
#43
```
[+] Building 134.4s (32/32) FINISHED                                                                                                                                                                            
 => [internal] load build definition from Dockerfile                                                                                                                                                       0.0s
 => => transferring dockerfile: 3.19kB                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                            0.0s
 => [linux/amd64 internal] load metadata for docker.io/library/alpine:latest                                                                                                                               2.8s
 => [linux/arm64 internal] load metadata for docker.io/library/alpine:latest                                                                                                                               2.7s
 => [linux/amd64  1/14] FROM docker.io/library/alpine@sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a                                                                              0.8s
 => => resolve docker.io/library/alpine@sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a                                                                                            0.0s
 => => sha256:8921db27df2831fa6eaa85321205a2470c669b855f3ec95d5a3c2b46de0442c9 3.37MB / 3.37MB                                                                                                             0.7s
 => => extracting sha256:8921db27df2831fa6eaa85321205a2470c669b855f3ec95d5a3c2b46de0442c9                                                                                                                  0.1s
 => [linux/arm64  1/14] FROM docker.io/library/alpine@sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a                                                                              0.7s
 => => resolve docker.io/library/alpine@sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a                                                                                            0.0s
 => => sha256:a9eaa45ef418e883481a13c7d84fa9904f2ec56789c52a87ba5a9e6483f2b74f 3.26MB / 3.26MB                                                                                                             0.6s
 => => extracting sha256:a9eaa45ef418e883481a13c7d84fa9904f2ec56789c52a87ba5a9e6483f2b74f                                                                                                                  0.1s
 => [linux/arm64  2/14] RUN apk add --update --no-cache curl ca-certificates bash git &&     curl -sL https://get.helm.sh/helm-v3.11.1-linux-arm64.tar.gz | tar -xvz &&     mv linux-arm64/helm /usr/bin/  3.4s
 => [linux/amd64  2/14] RUN apk add --update --no-cache curl ca-certificates bash git &&     curl -sL https://get.helm.sh/helm-v3.11.1-linux-amd64.tar.gz | tar -xvz &&     mv linux-amd64/helm /usr/bin/  5.8s
 => [linux/arm64  3/14] RUN helm plugin install https://github.com/databus23/helm-diff && rm -rf /tmp/helm-*                                                                                               5.3s
 => [linux/amd64  3/14] RUN helm plugin install https://github.com/databus23/helm-diff && rm -rf /tmp/helm-*                                                                                               8.2s
 => [linux/arm64  4/14] RUN helm plugin install https://github.com/quintush/helm-unittest && rm -rf /tmp/helm-*                                                                                            7.0s
 => [linux/amd64  4/14] RUN helm plugin install https://github.com/quintush/helm-unittest && rm -rf /tmp/helm-*                                                                                           12.5s
 => [linux/arm64  5/14] RUN helm plugin install https://github.com/chartmuseum/helm-push &&     rm -rf /tmp/helm-*     /root/.local/share/helm/plugins/helm-push/testdata     /root/.cache/helm/plugins/h  4.4s
 => [linux/arm64  6/14] RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v1.25.4/bin/linux/arm64/kubectl &&     mv kubectl /usr/bin/kubectl &&     chmod +x /usr/bin/kubectl        2.0s
 => [linux/arm64  7/14] RUN curl -sLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.0.0/kustomize_v5.0.0_linux_arm64.tar.gz &&     tar xvzf kustomize_v5.0.0_linux_arm64.  3.2s
 => [linux/arm64  8/14] RUN curl -sL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_arm64.tar.gz" | tar xz -C /tmp &&     mv /tmp/eksctl /usr/bin &&     chmod +x /usr  2.3s
 => [linux/amd64  5/14] RUN helm plugin install https://github.com/chartmuseum/helm-push &&     rm -rf /tmp/helm-*     /root/.local/share/helm/plugins/helm-push/testdata     /root/.cache/helm/plugins/h  5.6s
 => [linux/arm64  9/14] RUN apk add --update --no-cache python3 &&     python3 -m ensurepip &&     pip3 install --upgrade pip &&     pip3 install awscli &&     pip3 cache purge                          18.7s
 => [linux/amd64  6/14] RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v1.25.4/bin/linux/amd64/kubectl &&     mv kubectl /usr/bin/kubectl &&     chmod +x /usr/bin/kubectl        2.5s
 => [linux/amd64  7/14] RUN curl -sLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.0.0/kustomize_v5.0.0_linux_amd64.tar.gz &&     tar xvzf kustomize_v5.0.0_linux_amd64.  1.9s
 => [linux/amd64  8/14] RUN curl -sL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp &&     mv /tmp/eksctl /usr/bin &&     chmod +x /usr  3.8s
 => [linux/amd64  9/14] RUN apk add --update --no-cache python3 &&     python3 -m ensurepip &&     pip3 install --upgrade pip &&     pip3 install awscli &&     pip3 cache purge                          76.7s
 => [linux/arm64 10/14] RUN apk add --update --no-cache jq yq                                                                                                                                              1.2s
 => [linux/arm64 11/14] RUN authenticator=$(curl -fs https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest | jq --raw-output '.name' | sed 's/^v//') &&     curl -fL https:/  3.2s
 => [linux/arm64 12/14] RUN apk add --update --no-cache gettext                                                                                                                                            1.7s
 => [linux/arm64 13/14] RUN curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.19.4/kubeseal-0.19.4-linux-arm64.tar.gz -o - | tar xz -C /usr/bin/ &&     chmod +x /usr/bin/kubes  2.1s
 => [linux/arm64 14/14] WORKDIR /apps                                                                                                                                                                      0.0s
 => [linux/amd64 10/14] RUN apk add --update --no-cache jq yq                                                                                                                                              3.0s
 => [linux/amd64 11/14] RUN authenticator=$(curl -fs https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest | jq --raw-output '.name' | sed 's/^v//') &&     curl -fL https:/  5.0s
 => [linux/amd64 12/14] RUN apk add --update --no-cache gettext                                                                                                                                            2.6s
 => [linux/amd64 13/14] RUN curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.19.4/kubeseal-0.19.4-linux-amd64.tar.gz -o - | tar xz -C /usr/bin/ &&     chmod +x /usr/bin/kubes  3.0s
 => [linux/amd64 14/14] WORKDIR /apps                                                                                                                                                                      0.0s
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```