### PR TITLE
update build to support multi-arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,16 @@ parameters:
 
 jobs:
   build:
-    machine: true
+    docker:
+      - image: alpine/docker-with-buildx
     environment:
       REBUILD: << pipeline.parameters.rebuild >>
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 18.09.3
       - run: |
+          apk --no-cache --update add bash curl sudo
           bash ./build.sh
 
 workflows:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
 
+ARG ARCH
+
 # Ignore to update versions here
 # docker build --no-cache --build-arg KUBECTL_VERSION=${tag} --build-arg HELM_VERSION=${helm} --build-arg KUSTOMIZE_VERSION=${kustomize_version} -t ${image}:${tag} .
 ARG HELM_VERSION=3.2.1
@@ -9,13 +11,23 @@ ARG KUBESEAL_VERSION=0.18.1
 
 # Install helm (latest release)
 # ENV BASE_URL="https://storage.googleapis.com/kubernetes-helm"
-ENV BASE_URL="https://get.helm.sh"
-ENV TAR_FILE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
-RUN apk add --update --no-cache curl ca-certificates bash git && \
-    curl -sL ${BASE_URL}/${TAR_FILE} | tar -xvz && \
-    mv linux-amd64/helm /usr/bin/helm && \
+RUN case `uname -m` in \
+    x86_64) ARCH=amd64; ;; \
+    armv7l) ARCH=arm; ;; \
+    aarch64) ARCH=arm64; ;; \
+    ppc64le) ARCH=ppc64le; ;; \
+    s390x) ARCH=s390x; ;; \
+    *) echo "un-supported arch, exit ..."; exit 1; ;; \
+    esac && \
+    echo "export ARCH=$ARCH" > /envfile && \
+    cat /envfile
+
+RUN . /envfile && echo $ARCH && \
+    apk add --update --no-cache curl ca-certificates bash git && \
+    curl -sL https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz | tar -xvz && \
+    mv linux-${ARCH}/helm /usr/bin/helm && \
     chmod +x /usr/bin/helm && \
-    rm -rf linux-amd64
+    rm -rf linux-${ARCH}
 
 # add helm-diff
 RUN helm plugin install https://github.com/databus23/helm-diff && rm -rf /tmp/helm-*
@@ -25,23 +37,26 @@ RUN helm plugin install https://github.com/quintush/helm-unittest && rm -rf /tmp
 
 # add helm-push
 RUN helm plugin install https://github.com/chartmuseum/helm-push && \
-  rm -rf /tmp/helm-* \
+    rm -rf /tmp/helm-* \
     /root/.local/share/helm/plugins/helm-push/testdata \
     /root/.cache/helm/plugins/https-github.com-chartmuseum-helm-push/testdata
 
-# Install kubectl (same version of aws esk)
-RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+# Install kubectl
+RUN . /envfile && echo $ARCH && \
+    curl -sLO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl && \
     mv kubectl /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
 # Install kustomize (latest release)
-RUN curl -sLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
-    tar xvzf kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
+RUN . /envfile && echo $ARCH && \
+    curl -sLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz && \
+    tar xvzf kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz && \
     mv kustomize /usr/bin/kustomize && \
     chmod +x /usr/bin/kustomize
 
 # Install eksctl (latest version)
-RUN curl -sL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && \
+RUN . /envfile && echo $ARCH && \
+    curl -sL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_${ARCH}.tar.gz" | tar xz -C /tmp && \
     mv /tmp/eksctl /usr/bin && \
     chmod +x /usr/bin/eksctl
 
@@ -57,15 +72,17 @@ RUN apk add --update --no-cache jq yq
 
 # https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
 # Install aws-iam-authenticator (latest version)
-RUN authenticator=$(curl -fs https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest | jq --raw-output '.name' | sed 's/^v//') && \
-    curl -fL https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${authenticator}/aws-iam-authenticator_${authenticator}_linux_amd64 -o /usr/bin/aws-iam-authenticator && \
+RUN . /envfile && echo $ARCH && \
+    authenticator=$(curl -fs https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest | jq --raw-output '.name' | sed 's/^v//') && \
+    curl -fL https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${authenticator}/aws-iam-authenticator_${authenticator}_linux_${ARCH} -o /usr/bin/aws-iam-authenticator && \
     chmod +x /usr/bin/aws-iam-authenticator
 
 # Install for envsubst
 RUN apk add --update --no-cache gettext
 
 # Install kubeseal
-RUN curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz -o - | tar xz -C /usr/bin/ && \
+RUN . /envfile && echo $ARCH && \
+    curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-${ARCH}.tar.gz -o - | tar xz -C /usr/bin/ && \
     chmod +x /usr/bin/kubeseal
 
 WORKDIR /apps


### PR DESCRIPTION
multi-arch support attempt 3 (3rd time is the charm)

@ozbillwang I did some changes in the build script and tested in circleCI.
1. Circle CI link from my fork branch: https://app.circleci.com/pipelines/github/chenghu2/k8s/26/workflows/decc8b05-3df5-4a65-a427-baf4131b497e/jobs/25
1. Change the way that fetches Helm's latest tag, the current way always fetches an empty tag so I switched it to match other fetch tag styles.
2. Get the latest Kubernetes release versions: I completely changed this to not use the docker image since I couldn't figure it out why the volume doesn't work. The new script retrieves the list of all release tags for the Kubernetes repository on GitHub, then loops through them and extracts the minor version number (e.g., 1.18) from each release and finally get the latest version of each minor version.
3. With current changes, it will still not republish images unless there is a new K8s release. Here is what I propose to change and force republish multi-arch images. Let me know what you think!
```
for tag in "${latest_versions[@]}"; do
  echo ${tag}
  status=$(curl -sL https://hub.docker.com/v2/repositories/${image}/tags/${tag})
  echo $status
  image_count=$(echo $status | jq '.images | length')
  echo image_count: $image_count
  if [[ ( "${status}" =~ "not found" ) || $(echo $image_count) -le 1 ||( ${REBUILD} == "true" ) ]]; then
     echo "build image for ${tag}"
     build
  fi
done
```