### PR TITLE
don't install helm release candidates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,8 +19,8 @@ install_jq() {
 }
 
 build() {
-  # helm latest
-  helm=$(curl -s https://api.github.com/repos/helm/helm/releases | jq -r '.[].tag_name | select(startswith("v"))' \
+  # helm latest, hold the release candidates
+  helm=$(curl -s https://api.github.com/repos/helm/helm/releases | jq -r '.[].tag_name | select([startswith("v"), (contains("-rc") | not)] | all)' \
     | sort -rV | head -n 1 |sed 's/v//')
   echo "helm version is $helm"
 


### PR DESCRIPTION
The image of 1.25.10 I pulled in a build yesterday had a Helm that was broken in certain circumstances which I hit.

From the build log:
> `Using docker image sha256:f2bdd01674911bad6b219c6778ac99905670ed597f0fd556836d3a9bab1073dd for alpine/k8s:1.25.10 with digest alpine/k8s@sha256:e75160e5dd1a607a03e762ba03754d3a9e6cfb004fdd59add8a07931568eb74b ...`

The relevant issues:

- https://gitlab.com/gitlab-org/gitlab/-/issues/407161
- https://github.com/kubernetes/kubernetes/issues/117463
- https://github.com/helm/helm/issues/12071

As part of investigating my build failure, I noticed that alpine/k8s had a release candidate version of helm:

```
❯ docker run --rm alpine/k8s:1.25.10 helm version
version.BuildInfo{Version:"v3.12.0-rc.1", GitCommit:"c9f554d75773799f72ceef38c51210f1842a1dea", GitTreeState:"clean", GoVersion:"go1.20.3"}
```
Had it not had that, it would still have had 3.11.3, and I wouldn't have run into that issue.

Now, since that image was built, Helm released 3.12.0 which still has the bug—it's scheduled to land in 3.12.1—so it's not like this change would prevent buggy software from getting into the image. But I suspect that we probably don't want to be running pre-release versions of the utilities, any more than we do of Kubernetes itself.

The helm release tags don't include any `alpha` or `beta` tags, so I didn't include those in the filter. I also checked kustomize and kubeseal to see if they tag any pre-releases, but they don't.