### PR TITLE
Make Helm Plugins available to all users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,10 @@ RUN . /envfile && echo $ARCH && \
     chmod +x /usr/bin/helm && \
     rm -rf linux-${ARCH}
 
+ENV HELM_PLUGINS=/helm-plugins
+RUN mkdir -p "$HELM_PLUGINS" && \
+    chmod 755 "$HELM_PLUGINS"
+
 # add helm-diff
 RUN helm plugin install https://github.com/databus23/helm-diff && rm -rf /tmp/helm-*
 
@@ -38,7 +42,7 @@ RUN helm plugin install https://github.com/helm-unittest/helm-unittest && rm -rf
 # add helm-push
 RUN helm plugin install https://github.com/chartmuseum/helm-push && \
     rm -rf /tmp/helm-* \
-    /root/.local/share/helm/plugins/helm-push/testdata \
+    "$HELM_PLUGINS/helm-push/testdata" \
     /root/.cache/helm/plugins/https-github.com-chartmuseum-helm-push/testdata
 
 # Install kubectl


### PR DESCRIPTION
When running the image as a non-root user, the helm plugins can't be found because they are normally located at the user's home folder. During installation, they are installed to `/root`, which is not globally readable:

```shell
> docker run --rm -ti -u "1000:1000" alpine/k8s:1.27.4 helm unittest
Error: unknown command "unittest" for "helm"
Run 'helm --help' for usage.
```

But if we configure the `HELM_PLUGINS` environment variable, Helm will install AND look for the plugins at that folder. By making the folder globally readable, we allow any user to use the plugins (without being able to modify them):

```shell
> docker run --rm -ti -u "1000:1000" -v "$PWD:/apps" alpine/k8s:local helm unittest tests/dummy-chart

### Chart [ dummy-chart ] tests/dummy-chart

 PASS  images test      tests/dummy-chart/tests/images_test.yaml
 PASS  labels test      tests/dummy-chart/tests/labels_test.yaml
 PASS  names test       tests/dummy-chart/tests/names_test.yaml

Charts:      1 passed, 1 total
Test Suites: 3 passed, 3 total
Tests:       27 passed, 27 total
Snapshot:    0 passed, 0 total
Time:        38.429632ms
```

This is a much simpler change than #55 but should already help with people using the image in CI/CD environments where one can't use the root user.