### PR TITLE
Add krew as a new Tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 release.html
 release.txt
+
+# IDES
+.idea/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG HELM_VERSION=3.2.1
 ARG KUBECTL_VERSION=1.17.5
 ARG KUSTOMIZE_VERSION=v3.8.1
 ARG KUBESEAL_VERSION=0.18.1
+ARG KREW_VERSION=v0.4.4
 
 # Install helm (latest release)
 # ENV BASE_URL="https://storage.googleapis.com/kubernetes-helm"
@@ -85,5 +86,13 @@ RUN apk add --update --no-cache gettext
 RUN . /envfile && echo $ARCH && \
     curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-${ARCH}.tar.gz -o - | tar xz -C /usr/bin/ && \
     chmod +x /usr/bin/kubeseal
+
+# Install krew (latest release)
+RUN . /envfile && echo $ARCH && \
+    curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/krew-linux_${ARCH}.tar.gz" && \
+    tar zxvf krew-linux_${ARCH}.tar.gz && \
+    ./krew-linux_${ARCH} install krew && \
+    echo 'export PATH=/root/.krew/bin:$PATH' >> ~/.bashrc && \
+    rm krew-linux_${ARCH}.tar.gz
 
 WORKDIR /apps

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ kubernetes docker images with necessary tools
 - [eksctl](https://github.com/weaveworks/eksctl) (latest version when run the build)
 - [awscli v1](https://github.com/aws/aws-cli) (latest version when run the build)
 - [kubeseal](https://github.com/bitnami-labs/sealed-secrets) (latest version when run the build)
+- [krew](https://github.com/kubernetes-sigs/krew) (latest version when run the build)
 - General tools, such as bash, curl, jq, yq, etc
 
 ### Github Repo

--- a/build.sh
+++ b/build.sh
@@ -35,11 +35,17 @@ build() {
     | sort -rV | head -n 1 |sed 's/v//')
   echo "kubeseal version is $kubeseal_version"
 
+  # kubeseal latest
+  krew_version=$(curl -s https://api.github.com/repos/kubernetes-sigs/krew/releases/releases | jq -r '.[].tag_name | select(startswith("v"))' \
+    | sort -rV | head -n 1 |sed 's/v//')
+  echo "krew version is $krew_version"
+
   docker build --no-cache \
     --build-arg KUBECTL_VERSION=${tag} \
     --build-arg HELM_VERSION=${helm} \
     --build-arg KUSTOMIZE_VERSION=${kustomize_version} \
     --build-arg KUBESEAL_VERSION=${kubeseal_version} \
+    --build-arg KREW_VERSION=${krew_version} \
     -t ${image}:${tag} .
 
   # run test


### PR DESCRIPTION
From the comment in the following Issue https://github.com/alpine-docker/k8s/issues/38 I open this PR to add Krew.

`DOCKER_CMD` = Docker Run of the image

```
$(DOCKER_CMD) bash -c "source ~/.bashrc" && kubectl krew update
$(DOCKER_CMD) bash -c "source ~/.bashrc" && kubectl krew install modify-secret ns grep
```

I could not avoid the `bash -c "source ~/.bashrc"` command before the `kubecl krew`, if someone knows how to fix it, I will be glad of this feedback.