### PR TITLE
Add vals tool to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ARG KUBECTL_VERSION=1.17.5
 ARG KUSTOMIZE_VERSION=v3.8.1
 ARG KUBESEAL_VERSION=0.18.1
 ARG KREW_VERSION=v0.4.4
+ARG VALS_VERSION=0.28.1
+vals_0.28.1_darwin_amd64.tar.gz
+
 
 # Install helm (latest release)
 # ENV BASE_URL="https://storage.googleapis.com/kubernetes-helm"
@@ -86,6 +89,11 @@ RUN apk add --update --no-cache gettext
 RUN . /envfile && echo $ARCH && \
     curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-${ARCH}.tar.gz -o - | tar xz -C /usr/bin/ && \
     chmod +x /usr/bin/kubeseal
+
+# Install vals
+RUN . /envfile && echo $ARCH && \
+    curl -L https://github.com/helmfile/vals/releases/download/v${VALS_VERSION}/vals_${VALS_VERSION}_linux_${ARCH}.tar.gz -o -| tar xz -C /usr/bin/ && \
+    chmod +x /usr/bin/vals
 
 # Install krew (latest release)
 RUN . /envfile && echo $ARCH && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ ARG KUSTOMIZE_VERSION=v3.8.1
 ARG KUBESEAL_VERSION=0.18.1
 ARG KREW_VERSION=v0.4.4
 ARG VALS_VERSION=0.28.1
-vals_0.28.1_darwin_amd64.tar.gz
-
 
 # Install helm (latest release)
 # ENV BASE_URL="https://storage.googleapis.com/kubernetes-helm"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ kubernetes docker images with necessary tools
 - [awscli v1](https://github.com/aws/aws-cli) (latest version when run the build)
 - [kubeseal](https://github.com/bitnami-labs/sealed-secrets) (latest version when run the build)
 - [krew](https://github.com/kubernetes-sigs/krew) (latest version when run the build)
+- [vals](https://github.com/helmfile/vals) (latest version when run the build)
 - General tools, such as bash, curl, jq, yq, etc
 
 ### Github Repo

--- a/build.sh
+++ b/build.sh
@@ -35,10 +35,15 @@ build() {
     | sort -rV | head -n 1 |sed 's/v//')
   echo "kubeseal version is $kubeseal_version"
 
-  # kubeseal latest
+  # krew latest
   krew_version=$(curl -s https://api.github.com/repos/kubernetes-sigs/krew/releases | jq -r '.[].tag_name | select(startswith("v"))' \
     | sort -rV | head -n 1 |sed 's/v//')
   echo "krew version is $krew_version"
+
+  # vals latest
+  vals_version=$(curl -s https://api.github.com/repos/helmfile/vals/releases | jq -r '.[].tag_name | select(startswith("v"))' \
+    | sort -rV | head -n 1 |sed 's/v//')
+  echo "vals version is $vals_version"
 
   docker build --no-cache \
     --build-arg KUBECTL_VERSION=${tag} \
@@ -46,6 +51,7 @@ build() {
     --build-arg KUSTOMIZE_VERSION=${kustomize_version} \
     --build-arg KUBESEAL_VERSION=${kubeseal_version} \
     --build-arg KREW_VERSION=${krew_version} \
+    --build-arg VALS_VERSION=${vals_version} \
     -t ${image}:${tag} .
 
   # run test
@@ -71,6 +77,7 @@ build() {
       --build-arg KUSTOMIZE_VERSION=${kustomize_version} \
       --build-arg KUBESEAL_VERSION=${kubeseal_version} \
       --build-arg KREW_VERSION=${krew_version} \
+      --build-arg VALS_VERSION=${vals_version} \
       -t ${image}:${tag} .
   fi
 }


### PR DESCRIPTION
While using the GitHub action [deploy-eks-helm](https://github.com/bitovi/github-actions-deploy-eks-helm), when using helm secrets, we need the [vals](https://github.com/helmfile/vals) tool to work with the secret. 

We could install it, but I think the image can benefit from this tool. 

- Added vals into the Dockerfile, README and build.sh