### PR TITLE
build.sh: exclude helm versions containing a dash (`-`)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,8 +19,8 @@ install_jq() {
 }
 
 build() {
-  # helm latest, hold the release candidates
-  helm=$(curl -s https://api.github.com/repos/helm/helm/releases | jq -r '.[].tag_name | select([startswith("v"), (contains("-rc") | not)] | all)' \
+  # helm latest, hold prereleases
+  helm=$(curl -s https://api.github.com/repos/helm/helm/releases | jq -r '.[].tag_name | select([startswith("v"), (contains("-") | not)] | all)' \
     | sort -rV | head -n 1 |sed 's/v//')
   echo "helm version is $helm"
 


### PR DESCRIPTION
Helm just released `v4.0.0-alpha.1`, which does not match the existing `-rc` exclusion pattern. Instead of adding `-alpha` to the existing `-rc` pattern, I'm choosing to exclude anything with a dash instead. According to semver.org, pre-releases are indicated by a dash, so hopefully this should cover most cases while not excluding stable releases.

Closes https://github.com/alpine-docker/k8s/issues/85